### PR TITLE
Refine guide

### DIFF
--- a/FAQ-en.md
+++ b/FAQ-en.md
@@ -12,9 +12,9 @@ As common in the chip industry, Chip designs rarely are entirely different in a 
 
 Maybe.
 
-## I would like to help, how can I reach you
+## I would like to help, how can I reach you?
 
-We'll be happy to talk to you on our telegram channel: https://t.me/winonvayualt, note, you can help us with more than driver work, a lot of work is needed as well with documentation, support for the community, testing, developping apps, making a better shell, etc. We welcome any kind of help.
+We'll be happy to talk to you on our [telegram channel](https://t.me/winonvayualt), note, you can help us with more than driver work, a lot of work is needed as well with documentation, support for the community, testing, developping apps, making a better shell, etc. We welcome any kind of help.
 
 ## Are you going to do this for other Snapdragon™ 855 devices?
 

--- a/InstallWindows-en.md
+++ b/InstallWindows-en.md
@@ -2,19 +2,19 @@
 
 Welcome!
 
-## [Installing Windows](/InstallWindows-en/InstallWindows.md)
+### [Installing Windows](/InstallWindows-en/InstallWindows.md)
 
-## [Reinstalling Windows if it was already installed](/InstallWindows-en/ReinstallWindows.md)
+### [Reinstalling Windows if it was already installed](/InstallWindows-en/ReinstallWindows.md)
 
-## [Install Dual Boot](/InstallWindows-en/DualBoot.md)
+### [Install Dual Boot](/InstallWindows-en/DualBoot.md)
 
-## [Uninstalling Windows](/InstallWindows-en/Uninstall.md)
+### [Uninstalling Windows](/InstallWindows-en/Uninstall.md)
 
-## [Updating Drivers and/or UEFI](/Update-en/UpdateDriversAndUEFI.md)
+### [Updating Drivers and/or UEFI](/Update-en/UpdateDriversAndUEFI.md)
 
-## Help! Something is wrong and the guides do not seem to cover them
+## Help! Something is wrong and the guide does not seem to cover it
 
-- [Telegram Group, please send us a message, you may make things worse](https://t.me/winonvayualt)
+- [Telegram Group, please send us a message, you may make things worse otherwise.](https://t.me/winonvayualt)
 
 ---
 

--- a/InstallWindows-en/Cellular.md
+++ b/InstallWindows-en/Cellular.md
@@ -5,6 +5,7 @@
 Recovery image:
 
 11 image supports Android™ 11 encryption
+
 12 image supports Android™ 12/12.1/13/14 encryption
 
 | File Name                                       | Target Device         |
@@ -33,7 +34,7 @@ Cellular provisioning script:
 
 ## Booting to recovery
 
-- Reboot your deivce into recovery
+- Reboot your device into recovery
 
 ## Dumping Modem partitions using automated script
 
@@ -48,7 +49,7 @@ Cellular provisioning script:
 
 ## Dumping Modem partitions manually
 
-Using [the following guide](/Other/ExtractingPartitions.md), extract the following partitions:
+Using [the following guide](/Other-en/ExtractingPartitions.md), extract the following partitions:
 
 - ```modemst1```
 - ```modemst2```
@@ -57,9 +58,9 @@ once done, you should have obtained the ```modemst1.img``` and ```modemst2.img``
 
 Please note that your device is already in recovery, there's no need to put it back again into recovery. (So jump directly to the adb shell section of the above's guide).
 
-### Getting to Mass Storage Mode
+### Entering Mass Storage Mode
 
-- Let's run the mass storage shell script in order to boot into Mass Storage from recovery. You must decrypt your data if it asks you to.
+- Run the mass storage shell script in order to boot into Mass Storage from recovery. You must decrypt your data if it asks you to.
 
 ```batch
 adb shell msc
@@ -67,11 +68,11 @@ adb shell msc
 
 - If it asks you to run it once again, do so
 
-POCO X3 Pro should now be in USB Mass Storage Mode.
+Your POCO X3 Pro should now be in USB Mass Storage Mode.
 
 ### Copying files over
 
-Assuming the Windows partition is available under X: (will/may be different for you), do the following:
+Assuming the Windows partition is available under X: (may be different for you), do the following:
 
 - Copy the ```modemst1.img``` file to ```X:\Windows\System32\DriverStore\FileRepository\qcremotefs8150_<random data here>\bootmodem_fs1```
 - Copy the ```modemst2.img``` file to ```X:\Windows\System32\DriverStore\FileRepository\qcremotefs8150_<random data here>\bootmodem_fs2```

--- a/InstallWindows-en/DualBoot.md
+++ b/InstallWindows-en/DualBoot.md
@@ -17,7 +17,7 @@ UEFI Image:
 
 | File Name                              | Target Device         |
 |----------------------------------------|-----------------------|
-| POCO.X3.Pro.UEFI.img                   | POCO X3 Pro           |
+| POCO.X3.Pro.UEFI-v2XXX.XX.img          | POCO X3 Pro           |
 
 StA Installer:
 | File Name                              | Target Device         |
@@ -28,10 +28,10 @@ M3K WoA Helper:
 
 | File Name                              | Target Device         |
 |----------------------------------------|-----------------------|
-| [M3K-WoA-Helper.apk](https://github.com/woa-vayu-archive/WoA-Helper-M3K/releases/latest)                | POCO X3 Pro           |
+| [M3K-HelperX.X.apk](https://github.com/woa-vayu-archive/WoA-Helper-M3K/releases/latest)                | POCO X3 Pro           |
 
-- Stock device boot.img image obtained from an ota package, or from the device itself using **M3K WoA Helper**.
-- Rooted POCO X3 Pro with Windows already installed
+- Stock device boot.img image obtained from an OTA package, or from the device itself using **M3K WoA Helper** or by using [this guide](../Other-en/ExtractingPartitions.md).
+- Rooted POCO X3 Pro with Windows already installed.
 
 # Steps 🛠️
 
@@ -42,7 +42,7 @@ M3K WoA Helper:
 - Press the ```Mount Windows``` button, then download and move StA_Installer_vayu.exe to the newly created ```Windows``` folder in your internal storage.
 - Return to the M3K WoA Helper and press ```QuickBoot to Windows```.
 
-Your device will now boot into Windows
+Your device will now boot into Windows.
 
 ## Installing StA
 
@@ -50,8 +50,8 @@ Your device will now boot into Windows
 
 ## How it Works
 
-- To boot Android™, run ```Switch to Android``` shortcut on your desktop or start menu
-- To boot Windows, press ```QuickBoot to Windows``` inside the M3K WoA Helper
+- To boot Android™, run ```Switch to Android``` shortcut on your desktop or start menu.
+- To boot Windows, press ```QuickBoot to Windows``` inside the M3K WoA Helper.
 
 ---
 

--- a/InstallWindows-en/InstallWindows.md
+++ b/InstallWindows-en/InstallWindows.md
@@ -11,14 +11,14 @@
 
 There are three methods to install Windows:
 
-| **Comming Soon: Flash a Full Flash Update (FFU) file**                                                                       | **Coming Soon: Install Windows using automated scripts**                                                 | **Commin Soon: Install Windows Manually yourself**                                                                          |
+| **Coming Soon: Flash a Full Flash Update (FFU) file**                                                                       | **Coming Soon: Install Windows using automated scripts**                                                 | **Install Windows Manually yourself**                                                                          |
 |----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | <a href="/InstallWindows-en/FlashingFFU.md"><img src="https://github.com/WOA-Project/SurfaceDuo-Guides/assets/3755345/c4fd0391-210a-4c31-8f03-7db2e634430c" width="200"></a> | <a href="/InstallWindows-en/InstallWindows.md"><img src="https://github.com/WOA-Project/SurfaceDuo-Guides/assets/3755345/c4d1d3cd-b0aa-4a96-986b-929f5443865a" width="150"></a> | <a href="/InstallWindows-en/InstallWindowsManually.md"><img src="https://github.com/WOA-Project/SurfaceDuo-Guides/assets/3755345/9791796b-406b-4f0d-8aad-20fff18741da" width="200"></a> |
 | - Easiest                                                                                                      | - Easy                                                                                                         | - Hardest                                                                                                      |
 | - Quickest                                                                                                     | - Takes a little bit of time                                                                                   | - Longest                                                                                                      |
 | - Simple                                                                                                       | - Doable for most people                                                                                       | - Complicated for inexperienced user, and can lead to mistakes breaking the device if done incorrectly         |
-| - Lack of options in regards to OS version, language, edition, storage allocation | - Customizable in regards to OS version, language, edition, storage allocation | - Highly customizable in regards to OS version, language, edition, storage allocation |
-| [Comming Soon!](/InstallWindows-en/InstallWindows.md) | [Coming Soon!](/InstallWindows-en/InstallWindows.md) | [Manual Guide](/InstallWindows-en/InstallWindowsManually.md) |
+| - Lack of options in regards to OS version, language, edition and storage allocation | - Customizable in regards to OS version, language, edition and storage allocation | - Highly customizable in regards to OS version, language, edition and storage allocation |
+| [Coming Soon!](/InstallWindows-en/InstallWindows.md) | [Coming Soon!](/InstallWindows-en/InstallWindows.md) | [Manual Guide](/InstallWindows-en/InstallWindowsManually.md) |
 
 ---
 

--- a/InstallWindows-en/InstallWindowsManually.md
+++ b/InstallWindows-en/InstallWindowsManually.md
@@ -10,8 +10,8 @@ Table of Contents:
 * [Steps 🛠️](#steps-️)
    * [Unlocking the Bootloader](#unlocking-the-bootloader)
    * [Partitioning](#partitioning)
-   * [Getting to Mass Storage Mode](#getting-to-mass-storage-mode)
-   * [Going to Mass Storage](#going-to-mass-storage)
+   * [Getting the Mass Storage Script](#getting-the-mass-storage-script)
+   * [Entering Mass Storage Mode](#entering-mass-storage-mode)
    * [Installing Windows](#installing-windows)
    * [Installing the drivers](#installing-the-drivers)
    * [Boot Windows 🚀](#boot-windows-)
@@ -25,7 +25,7 @@ UEFI Image:
 
 | File Name                              | Target Device         |
 |----------------------------------------|-----------------------|
-| POCO.X3.Pro.UEFI.img                   | POCO X3 Pro           |
+| POCO.X3.Pro.UEFI-v2XXX.XX.img          | POCO X3 Pro           |
 
 Windows Drivers:
 
@@ -36,6 +36,7 @@ Windows Drivers:
 Recovery image:
 
 11 image supports Android™ 11 encryption
+
 12 image supports Android™ 12/12.1/13/14 encryption
 
 | File Name                                       | Target Device         |
@@ -93,7 +94,7 @@ Here's how to acquire a Driver archive file and the matching UEFI image for POCO
 </td>
 <td>
 
-- [Fast Boot](https://github.com/woa-vayu-archive/POCOX3Pro-Releases/releases/download/2406.06/POCO.X3.Pro.UEFI-v2406.06.img)
+[POCO.X3.Pro.UEFI-v2406.06.img](https://github.com/woa-vayu-archive/POCOX3Pro-Releases/releases/download/2406.06/POCO.X3.Pro.UEFI-v2406.06.img)
 </td>
 <td>POCO X3 Pro</td>
 <td>Windows 10 Version 2004 and higher</td>
@@ -148,7 +149,7 @@ If not already done, please first unlock the bootloader. Come back once you're d
 
 If not already done, please proceed with the [Partitioning](Partitioning.md) guide for POCO X3 Pro. Come back once you're done. If you already followed this guide, please instead follow the [Reinstall Windows](ReinstallWindows.md) guide, not this one.
 
-## Getting to Mass Storage Mode
+## Getting the Mass Storage Script
 
 - Reboot into the Bootloader mode by running this command while inside Android™:
 
@@ -164,7 +165,7 @@ Start by flashing recovery:
 fastboot flash recovery
 ```
 
-- Go find the recovery image file you downloaded earlier, right click it, click "Copy as path"
+- Go find the recovery image file you downloaded earlier, hold shift and right click it, click "Copy as path"
 
 - Then go back to the Command Prompt window we started writing text in previously, and simply, right click on it with your mouse (or long press if you're on a touch device) and press enter
 
@@ -174,9 +175,9 @@ fastboot flash recovery
 fastboot reboot recovery
 ```
 
-You will now boot to SHPR/TWRP.
+You will now boot to SHRP/TWRP.
 
-## Going to Mass Storage
+## Entering Mass Storage Mode
 
 - Let's run the mass storage shell script in order to boot into Mass Storage from recovery. You must decrypt your data if it asks you to.
 
@@ -186,7 +187,7 @@ adb shell msc
 
 - If it asks you to run it once again, do so
 
-POCO X3 Pro should now be in USB Mass Storage Mode.
+Your POCO X3 Pro should now be in USB Mass Storage Mode.
 
 ## Installing Windows
 
@@ -206,14 +207,14 @@ Find the POCO X3 Pro Disk, and take note of the number.
 You will be able to recognize the partitions we made earlier by their size. take note of the ESP and WIN partition numbers.
 # select partition <esp-partition-number(Usually it's 34)>
 # assign letter=<THE LETTER YOU WANT AS LONG AS IT IS NOT CURRENTLY IN USE IN FILE EXPLORER FOR ANOTHER DRIVE! (Example: Y)>:
-# select partition <win-partition-number(Usually it's 33)>
+# select partition <windows-partition-number(Usually it's 33)>
 # assign letter=<ANOTHER LETTER YOU WANT AS LONG AS IT IS NOT CURRENTLY IN USE IN FILE EXPLORER FOR ANOTHER DRIVE! (Example: X)>:
 ```
 
-- You will have two partitions loaded, one is the ESP partition, and the other is the Win partition. Take note of the letters you've used.
+- You will have two partitions loaded, one is the ESP partition, and the other is the Windows partition. Take note of the letters you've used.
 
 > [!WARNING]
-From now on we will assume X: is the Win partition and that Y: is the ESP partition for all the commands. You very very likely used other letters, or have to use other letters. Replace them correctly with what you previously picked or you will lose data on your PC.
+From now on we will assume X: is the Windows partition and that Y: is the ESP partition for all the commands. You very very likely used other letters, or have to use other letters. Replace them correctly with what you previously picked or you will lose data on your PC.
 
 - We will need our install.wim file now. If you haven't it already, you can [use this guide](/InstallWindows-en/ISO/GetWindows.md). When you are ready, run these commands:
 
@@ -261,7 +262,7 @@ You will be back into POCO X3 Pro bootloader.
 
 We are ready to boot for the first time!
 
-Reboot your device to the Bootloader mode, using adb or from the recovery.
+Reboot your device to the Bootloader mode, using adb or the recovery.
 
 Let's boot the UEFI, from a command prompt:
 
@@ -295,7 +296,7 @@ In case you want the dual boot option, then follow [this guide](/InstallWindows-
   <summary>In case you want to manually boot each time: (<b>Click to expand</b>)</summary>
   <p>
 
-Reboot your device to the Bootloader mode, using adb or from the recovery.
+Reboot your device to the Bootloader mode, using adb or the recovery.
 
 Let's boot the UEFI, from a command prompt:
 
@@ -306,8 +307,6 @@ fastboot boot uefi.img
 This step above will be needed every time you will want to boot Windows and needs to be done from the Bootloader mode.
 
 If you did everything right, Windows will now boot! Enjoy!
-
-**Note:** If the Touch keyboard won't show up in OOBE, touch somewhere else (to let the text box loose focus) and then touch into the text box again. As an alternative, you can use the On-Screen Keyboard.
   </p>
 </details>
 

--- a/InstallWindows-en/Partitioning.md
+++ b/InstallWindows-en/Partitioning.md
@@ -5,6 +5,7 @@
 Recovery image:
 
 11 image supports Android™ 11 encryption
+
 12 image supports Android™ 12/12.1/13/14 encryption
 
 | File Name                                       | Target Device         |
@@ -132,7 +133,7 @@ You will now boot to recovery. Keep the phone plugged to your PC and continue al
 - Let's run partitioning script:
 
 ```bash
-adb shell partition [Amount of storage you want Windows to have (only number)]
+adb shell partition [Amount of storage you want Windows to have (only as a number in GB e.g 64 for 64GB)]
 ```
 
 - If it asks you to run it once again, do so

--- a/InstallWindows-en/ReinstallWindows.md
+++ b/InstallWindows-en/ReinstallWindows.md
@@ -8,7 +8,7 @@ UEFI Image:
 
 | File Name                              | Target Device         |
 |----------------------------------------|-----------------------|
-| POCO.X3.Pro.UEFI.img                   | POCO X3 Pro           |
+| POCO.X3.Pro.UEFI-v2XXX.XX.img          | POCO X3 Pro           |
 
 Windows Drivers:
 
@@ -19,6 +19,7 @@ Windows Drivers:
 Recovery image:
 
 11 image supports Android™ 11 encryption
+
 12 image supports Android™ 12/12.1/13/14 encryption
 
 | File Name                                       | Target Device         |
@@ -103,7 +104,7 @@ Now the Windows Partition on your POCO X3 Pro should be empty. Let's go ahead an
 
 ## Getting to Mass Storage Mode
 
-- Please turn your phone and boot to recovery again before proceding further
+- Please restart your phone and boot it into recovery again before proceding further.
 
 - Let's run the mass storage shell script in order to boot into Mass Storage from recovery. You must decrypt your data if it asks you to.
 
@@ -111,11 +112,11 @@ Now the Windows Partition on your POCO X3 Pro should be empty. Let's go ahead an
 adb shell msc
 ```
 
-POCO X3 Pro should now be in USB Mass Storage Mode.
+Your POCO X3 Pro should now be in USB Mass Storage Mode.
 
 ## Installing Windows
 
-- Make sure you are in Mass Storage Mode, that your POCO X3 Pro is plugged into your PC
+- Make sure you are in Mass Storage Mode and your POCO X3 Pro is plugged into your PC.
 - Mount the partitions you have created using diskpart and assign them some letters:
 
 ```batch
@@ -130,15 +131,15 @@ Find the POCO X3 Pro Disk, and take note of the number.
 # list partition
 You will be able to recognize the partitions we made earlier by their size. take note of the ESP and WIN partition numbers.
 # select partition <esp-partition-number(Usually it's 34)>
-# assign letter=<THE LETTER YOU WANT AS LONG AS IT IS NOT CURRENTLY IN USE IN FILE EXPLORER FOR ANOTHER DRIVE! (Example: X)>:
-# select partition <win-partition-number(Usually it's 33)>
-# assign letter=<ANOTHER LETTER YOU WANT AS LONG AS IT IS NOT CURRENTLY IN USE IN FILE EXPLORER FOR ANOTHER DRIVE! (Example: Y)>:
+# assign letter=<THE LETTER YOU WANT AS LONG AS IT IS NOT CURRENTLY IN USE IN FILE EXPLORER FOR ANOTHER DRIVE! (Example: Y)>:
+# select partition <windows-partition-number(Usually it's 33)>
+# assign letter=<ANOTHER LETTER YOU WANT AS LONG AS IT IS NOT CURRENTLY IN USE IN FILE EXPLORER FOR ANOTHER DRIVE! (Example: X)>:
 ```
 
-- You will have two partitions loaded, one is the ESP partition, and the other is the Win partition. Take note of the letters you've used.
+- You will have two partitions loaded, one is the ESP partition, and the other is the Windows partition. Take note of the letters you've used.
 
 > [!WARNING]
-From now on we will assume X: is the Win partition and that Y: is the ESP partition for all the commands. You very very likely used other letters, or have to use other letters. Replace them correctly with what you previously picked or you will lose data on your PC.
+From now on we will assume X: is the Windows partition and that Y: is the ESP partition for all the commands. You very very likely used other letters, or have to use other letters. Replace them correctly with what you previously picked or you will lose data on your PC.
 
 - We will need our install.wim file now. If you haven't it already, you can [use this guide](/InstallWindows-en/ISO/GetWindows.md). When you are ready, run these commands:
 
@@ -151,7 +152,6 @@ This will take a bit of time. Go make some coffee ☕ or some tea 🍵.
 - Once that is done:
 
 ```batch
-rmdir /Q /S Y:\EFI
 bcdboot X:\Windows /s Y: /f UEFI
 ```
 
@@ -201,7 +201,7 @@ In case you want the dual boot option, then follow [this guide](/InstallWindows-
   <summary>In case you want to manually boot each time: (<b>Click to expand</b>)</summary>
   <p>
 
-Reboot your device to the Bootloader mode, using adb or from the recovery.
+Reboot your device to the Bootloader mode, using adb or the recovery.
 
 Let's boot the UEFI, from a command prompt:
 
@@ -212,8 +212,6 @@ fastboot boot uefi.img
 This step above will be needed every time you will want to boot Windows and needs to be done from the Bootloader mode.
 
 If you did everything right, Windows will now boot! Enjoy!
-
-**Note:** If the Touch keyboard won't show up in OOBE, touch somewhere else (to let the text box loose focus) and then touch into the text box again. As an alternative, you can use the On-Screen Keyboard.
   </p>
 </details>
 

--- a/InstallWindows-en/Uninstall.md
+++ b/InstallWindows-en/Uninstall.md
@@ -69,6 +69,8 @@ Save the file on your computer, and extract the zip file by opening it, and sele
 
 ## Booting to recovery
 
+- If not already done, please proceed with the installing recovery as told in **Getting the Mass Storage Script** section in [Main guide](/InstallWindows-en/InstallWindowsManually.md) for the POCO X3 Pro. Come back once you're done.
+
 - Reboot your deivce into recovery
 
 ## Restoring the original partitions
@@ -93,7 +95,7 @@ exit
 
 - Once your phone is confirmed working, congratulations, you successfully uninstalled Windows from your device.
 
-You may however want to also relock the bootloader of the device, please note that you cannot relock the bootloader of your device if you flashed a custom rom as well as installed Windows before, or modified the boot partition for your own purposes.
+You may however want to also relock the bootloader of the device, please note that you cannot relock the bootloader of your device if you flashed a custom rom as well as installed Windows without uninstalling it, or modified the boot partition for your own purposes.
 
 🎉 Congratulations, your POCO X3 Pro is back to factory settings.
 

--- a/Other-en/ExtractingPartitions.md
+++ b/Other-en/ExtractingPartitions.md
@@ -5,6 +5,7 @@
 Recovery image:
 
 11 image supports Android™ 11 encryption
+
 12 image supports Android™ 12/12.1/13/14 encryption
 
 | File Name                                       | Target Device         |
@@ -65,13 +66,16 @@ Save the file on your computer, and extract the zip file by opening it, and sele
 
 ## Boot into recovery
 
-- If not already done, please proceed with the installing recovery as told in [Getting to Mass Storage Mode] section in [Main guide](/InstallWindows-en/InstallWindowsManually.md) for POCO X3 Pro. Come back once you're done.
+- If not already done, please proceed with the installing recovery as told in **Getting the Mass Storage Script** section in [Main guide](/InstallWindows-en/InstallWindowsManually.md) for the POCO X3 Pro. Come back once you're done.
 
 - Reboot into recovery
 
-Your POCO X3 Pro will boot into TWRP, touch will not work and the device will say it is locked. This is completely normal and expected.
+Your POCO X3 Pro will boot into TWRP/SHRP.
 
-## Retrieve the location of our boot partition
+## Retrieve the location of our target partition
+
+> [!WARNING]
+> From now on we will assume you are trying to extract the boot partition, if not, replace "boot" with the name of the partition you are trying to extract.
 
 - We need to open a shell to issue commands directly to the phone. To do so, run the following command on your PC:
 
@@ -81,7 +85,7 @@ adb shell
 
 You are now able to issue commands directly to your phone via your PC.
 
-- Now, we need to find the location of our boot partition, as it is different for each device. To do so, run the following command on your PC:
+- Now, we need to find the location of our target partition, as it is different for each device. To do so, run the following command on your PC:
 
 ```bash
 ls /dev/block/by-name/

--- a/Status-en.md
+++ b/Status-en.md
@@ -7,8 +7,8 @@
 |------------------------|-----------------------------------------------------------------------------------------|----------------|
 | ⌨️ Side buttons        |                                     | ✅            |
 | ♋ Cellular Calls      |                                     | ❌            |
-| ♋ Cellular Data       | Requires manial provisioning.       | ✅            |
-| ♋ Cellular Texts      | Requires manial provisioning.       | ✅            |
+| ♋ Cellular Data       | Requires manual provisioning.       | ✅            |
+| ♋ Cellular Texts      | Requires manual provisioning.       | ✅            |
 | ♋ Wifi                |                                     | ✅            |
 | 📦 UFS                 |                                     | ✅            |
 | 🔵 Bluetooth           |                                     | ✅            |
@@ -26,7 +26,7 @@
 | 📸 Camera Flash        |                                     | ❌            |
 | 🏷️ NFC                 |                                     | ❌            |
 | 📸 Camera              |                                     | ❌            |
-| 🧑‍💼 Hyper-V             | Requires Microsoft Corporation Signed device configuration binary  | ❌           |
+| 🧑‍💼 Hyper-V             | Requires Xiaomi Corporation Signed device configuration binary  | ❌           |
 | 🧬 Fingerprint scanner |                                     | ❌            |
 
 # Detailed status

--- a/Update-en/UpdateDriversAndUEFI.md
+++ b/Update-en/UpdateDriversAndUEFI.md
@@ -13,7 +13,7 @@ UEFI Image:
 
 | File Name                              | Target Device         |
 |----------------------------------------|-----------------------|
-| POCO.X3.Pro.UEFI.img                   | POCO X3 Pro           |
+| POCO.X3.Pro.UEFI-v2XXX.XX.img          | POCO X3 Pro           |
 
 Windows Drivers:
 
@@ -24,6 +24,7 @@ Windows Drivers:
 Recovery image:
 
 11 image supports Android™ 11 encryption
+
 12 image supports Android™ 12/12.1/13/14 encryption
 
 | File Name                                       | Target Device         |
@@ -80,11 +81,11 @@ Save the file on your computer, and extract the zip file by opening it, and sele
   </p>
 </details>
 
-## Getting to Mass Storage Mode
+## Entering Mass Storage Mode
 
 - Reboot your deivce into recovery
 
-- Let's run the mass storage shell script in order to boot into Mass Storage from recovery. You must decrypt your data if it asks you to.
+- Run the mass storage shell script in order to boot into Mass Storage from recovery. You must decrypt your data if it asks you to.
 
 ```batch
 adb shell msc
@@ -92,12 +93,12 @@ adb shell msc
 
 - If it asks you to run it once again, do so
 
-POCO X3 Pro should now be in USB Mass Storage Mode.
+Your POCO X3 Pro should now be in USB Mass Storage Mode.
 
 ## Updating Drivers
 
 > [!WARNING]
-> From now on we will assume X: is the Win partition for all commands. Replace them correctly with what you previously picked or you will lose data on your PC.
+> From now on we will assume X: is the Windows partition for all commands. Replace them correctly with what you previously picked or you will lose data on your PC.
 
 - Download the latest driver package from https://github.com/woa-vayu-archive/POCOX3Pro-Releases/releases/latest
 
@@ -137,7 +138,7 @@ Simply use the latest UEFI image
 fastboot boot uefi.img
 ```
 
-### For Dual Boot follow [Dual Boot](/InstallWindows-en/DualBoot.md) guide again
+### For Dual Boot installations, follow the [Dual Boot](/InstallWindows-en/DualBoot.md) guide again.
 
 ---
 


### PR DESCRIPTION
Fixes typos, also removes the unnecessary line where it rmdirs the ESP, we dont need to do that since ESP is already formated by the recovery 